### PR TITLE
Re-enable partial hydration

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -4,13 +4,3 @@
  * See: https://www.gatsbyjs.com/docs/browser-apis/
  */
 
-const ReactDOM = require("react-dom/client");
-
-// See https://github.com/gatsbyjs/gatsby/discussions/36232; it would be ideal to get rid of this, but integration tests fail in ci without it
-
-exports.replaceHydrateFunction = () => {
-  return (element, container) => {
-    const root = ReactDOM.createRoot(container);
-    root.render(element);
-  };
-};


### PR DESCRIPTION
See https://github.com/gatsbyjs/gatsby/discussions/36232. The move to React 18 broke hydration. Frustratingly, the error does not show up in dev mode, even with `DEV_SSR`, and does not show up in local integration test runs. It does show up in CI, though. 

Hopefully eventually it will be sorted out by some change or dependency update. This PR should be rebased every now and then and re-checked.